### PR TITLE
Ir instruction builder functions

### DIFF
--- a/budvm/src/lib.rs
+++ b/budvm/src/lib.rs
@@ -1133,6 +1133,12 @@ impl ValueKind {
     }
 }
 
+impl From<&ValueKind> for ValueKind {
+    fn from(value: &ValueKind) -> Self {
+        value.clone()
+    }
+}
+
 impl<'a> From<&'a str> for ValueKind {
     fn from(kind: &'a str) -> Self {
         match kind {
@@ -1151,6 +1157,17 @@ impl From<Symbol> for ValueKind {
             "Real" => ValueKind::Real,
             "Boolean" => ValueKind::Boolean,
             _ => ValueKind::Dynamic(kind),
+        }
+    }
+}
+
+impl From<&Symbol> for ValueKind {
+    fn from(kind: &Symbol) -> Self {
+        match kind.as_str() {
+            "Integer" => ValueKind::Integer,
+            "Real" => ValueKind::Real,
+            "Boolean" => ValueKind::Boolean,
+            _ => ValueKind::Dynamic(kind.clone()),
         }
     }
 }

--- a/budvm/src/symbol.rs
+++ b/budvm/src/symbol.rs
@@ -66,6 +66,12 @@ impl PartialEq for Symbol {
     }
 }
 
+impl From<&Symbol> for Symbol {
+    fn from(value: &Symbol) -> Self {
+        value.clone()
+    }
+}
+
 #[derive(Debug, Clone)]
 struct SharedData(Arc<Data>);
 


### PR DESCRIPTION
- add if else helpers to CodeBlockBuilder (#17)
- add functions on CodeBlockBuilder to directly create and push instructions
- [ ] add `Stack` unit struct that can be used both for values and destinations.
- [ ] consider implementing `From<Label>` for `CompareAction` but that might be a bit confusing.
